### PR TITLE
Make mockr usable interactively

### DIFF
--- a/R/env.R
+++ b/R/env.R
@@ -22,10 +22,10 @@
 get_mock_env <- function(.parent = parent.frame()) {
   top <- topenv(.parent)
 
-  testing <- is_installed("testthat") && testthat::is_testing()
-  if (!testing) {
-    return(top)
-  }
+  # testing <- is_installed("testthat") && testthat::is_testing()
+  # if (!testing) {
+  #   return(top)
+  # }
 
   pkg <- testthat::testing_package()
   if (pkg != "") {
@@ -108,7 +108,7 @@ create_mock_env_with_old_funcs <- function(new_funcs, .env, .parent) {
   # retrieve all functions not mocked
   old_funcs <- as.list(.env, all.names = TRUE)
   old_funcs <- old_funcs[vlapply(old_funcs, is.function)]
-  old_funcs <- old_funcs[!(names(old_funcs) %in% names(new_funcs))]
+  old_funcs <- old_funcs[!(names(old_funcs) %in% c(".onLoad", names(new_funcs)))]
 
   # query value visible from .parent to support nesting
   old_funcs <- mget(names(old_funcs), .parent, inherits = TRUE)


### PR DESCRIPTION
This is not a terribly serious pull request, but these changes are allowing me to use mockr at the moment. There's a lot I don't understand about the environment choices here.

As explained elsewhere I have this in `tests/testthat/helper.R` of the package I am testing (gargle, in this example):

``` r
with_mock <- function(..., .parent = parent.frame()) {
  mockr::with_mock(..., .parent = .parent, .env = "gargle")
}
```